### PR TITLE
Remove abstract elements (Stmt/ExprStmt) and defined them as model

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -2,4 +2,5 @@ include(UseLATEX)
 
 add_latex_document(main.tex
   INPUTS example.tex  expression_elements.tex  intro.tex  macro.tex  main.tex root_element.tex statement_elements.tex 
+         common_elements.tex
 )

--- a/doc/common_elements.tex
+++ b/doc/common_elements.tex
@@ -1,5 +1,5 @@
 \section{Common elements}
-The definitions commonly used in an arvitrary element are shown in this Section.
+The definitions commonly used in an arbitrary element are shown in this Section.
 
 \model{stmtModel}
 The {\tt stmtModel} is commonly used for elements that refer statements.

--- a/doc/common_elements.tex
+++ b/doc/common_elements.tex
@@ -1,0 +1,21 @@
+\section{Common elements}
+The definitions commonly used in an arvitrary element are shown in this Section.
+
+\model{stmtModel}
+The {\tt stmtModel} is commonly used for elements that refer statements.
+
+\subsubsection*{ContentsModel}{}
+
+\begin{lstlisting}[style=default]
+(^\concept{VarDecl}^|^\concept{IfStmt}^|^\concept{BlockStmt}^)
+\end{lstlisting}
+
+
+\model{exprModel}
+The {\tt exprModel} is commonly used for elements that refer expression.
+
+\subsubsection*{ContentsModel}{}
+
+\begin{lstlisting}[style=default]
+(^\concept{UnaryOp}^|^\concept{TernaryOp}^|^\concept{AssignmentOp}^)
+\end{lstlisting}

--- a/doc/example.tex
+++ b/doc/example.tex
@@ -119,12 +119,12 @@ Program {
           name : mu0_inv
         }
         rhs : BinaryOp {
-          lhs : Literal {
+          lhs : VarAccess {
+            name : mu0
+          }
+          rhs : Literal {
             type : real
             value : 1.0
-          }
-          rhs : VarAccess {
-            name : mu0
           }
           operator : /
         }

--- a/doc/example.tex
+++ b/doc/example.tex
@@ -114,21 +114,19 @@ Program {
     BlockStmt {
       // Computation, this is the only stmt that we will express as a tree. 
       // From this on, pseudocode for the statements will be used
-      ExprStmt { 
-        AssignmentOp {
-          lhs : VarAccess {
-            name : mu0_inv
+      AssignmentOp {
+        lhs : VarAccess {
+          name : mu0_inv
+        }
+        rhs : BinaryOp {
+          lhs : Literal {
+            type : real
+            value : 1.0
           }
-          rhs : BinaryOp {
-            lhs : Literal {
-              type : real
-              value : 1.0
-            }
-            rhs : VarAccess {
-              name : mu0
-            }
-            operator : /
+          rhs : VarAccess {
+            name : mu0
           }
+          operator : /
         }
       }
       Computation {

--- a/doc/macro.tex
+++ b/doc/macro.tex
@@ -5,11 +5,16 @@
 \def\DDAG{$^\ddagger$}
 %
 \newcommand{\concept}[1]{
-\hyperref[cp:#1]{#1}	
+\hyperref[cp:#1]{#1}
 }
 
 \newcommand{\element}[1] {
 \subsection{{\tt #1} element}
+\label{cp:#1}
+}
+
+\newcommand{\model}[1] {
+\subsection{{\tt #1} model}
 \label{cp:#1}
 }
 

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -98,6 +98,7 @@ of XXX Project.
 \input{root_element.tex}
 \input{statement_elements.tex}
 \input{expression_elements.tex}
+\input{common_elements.tex}
 \input{example.tex}
 
 \cleardoublepage

--- a/doc/root_element.tex
+++ b/doc/root_element.tex
@@ -7,7 +7,7 @@ Description of the element {\tt Program} element:
 \subsubsection*{ContentsModel}{}
 
 \begin{lstlisting}[style=default]
-(^\concept{Dimension}^[dimension]+,^\concept{Domain}^[domain], ^\concept{FieldDecl}^[field]+, ^\concept{VarDecl}^[vararg]*, (^\concept{ScopedProgram}^|^\concept{ExternalKernel}^)[scope]+)
+(^\concept{GridDimension}^[dimension]+,^\concept{Domain}^[domain], ^\concept{FieldDecl}^[field]+, ^\concept{VarDecl}^[vararg]*, (^\concept{ScopedProgram}^|^\concept{ExternalKernel}^)[scope]+)
 \end{lstlisting}
 
 \begin{HIRChildElements}

--- a/doc/root_element.tex
+++ b/doc/root_element.tex
@@ -54,7 +54,7 @@ The domain provides domain information of the application that is used as hints 
 	\HIRElementDef{vertical\_dim}
 	{specifies the vertical dimension}{R}
 	\HIRElementDef{parallel\_dim}
-	{specifies dimensions on which computations are embarrassingly parallel}{R}	
+	{specifies dimensions on which computations are embarrassingly parallel}{R}
 \end{HIRChildElements}
 
 \element{ScopedProgram}
@@ -68,7 +68,7 @@ The {\tt ScopedProgram} defines all the computations performed using concepts of
 \end{lstlisting}
 
 \begin{HIRChildElements}
-	\HIRElementDef{Stmt}
+	\HIRElementDef{BlockStmt}
 	{Block statement containing the sequence of statements that forms the computation of the program}{R}
 \end{HIRChildElements}
 
@@ -87,12 +87,12 @@ The {\tt ExternalKernel} defines a call to an external kernel, for which computa
 	{defines the list of input fields}{R}
 	\HIRElementDef{output}
 	{defines the list of output fields}{R}
-		
+
 \end{HIRChildElements}
 
 \element{GridDimension}
 
-The {\tt GridDimension} elements defines a dimension of a multidimensional space where fields are discretized and over which \concept{Computation}s iterate. 
+The {\tt GridDimension} elements defines a dimension of a multidimensional space where fields are discretized and over which \concept{Computation}s iterate.
 
 \HIRContentsModel{ () }
 \begin{HIRAttributes}
@@ -114,12 +114,12 @@ The {\tt DimensionLevel} it is used to specify a position (that is specified as 
 	\HIRElementDef{var\_placeholder}
 	{It uses a scalar variable of rank N where each element act as a marker, whose runtime values will store the positions within the extent of the dimension.}{R}
 	\HIRElementDef{offset}
-	{It is a integer offset that shifts the position of the level with respect to the value of the var\_placeholder }{R}	
+	{It is a integer offset that shifts the position of the level with respect to the value of the var\_placeholder }{R}
 \end{HIRChildElements}
 
 \element{DimensionInterval}
 
-The {\tt DimensionInterval} defines an interval on a dimension. 
+The {\tt DimensionInterval} defines an interval on a dimension.
 
 \subsubsection*{ContentsModel}{}
 
@@ -154,7 +154,7 @@ The {\tt FieldDecl} element defines a multidimensional field storage
 	\HIRElementDef{GridDimension}
 	{dimensions of the multidimensional space where the storage is defined}{R}
 	\HIRElementDef{Type}
-	{value type of the grid elements of the field}{R}	
+	{value type of the grid elements of the field}{R}
 \end{HIRChildElements}
 
 \begin{HIRAttributes}
@@ -183,7 +183,7 @@ The {\tt Offset} is the relative distance in a given \concept{GridDimension} to 
 \end{HIRAttributes}
 
 \element{Computation}
-The {\tt Computation} defines an iteration loop over the specified \concept{GridDimension}s of the domain. 
+The {\tt Computation} defines an iteration loop over the specified \concept{GridDimension}s of the domain.
 
 \subsubsection*{ContentsModel}{}
 
@@ -193,7 +193,7 @@ The {\tt Computation} defines an iteration loop over the specified \concept{Grid
 
 \begin{HIRChildElements}
 	\HIRElementDef{GridDimension[dimension]}
-	{Specifies the dimensions where the computation is defined, 
+	{Specifies the dimensions where the computation is defined,
 		convering the whole extent of the grid for that dimension}{O}
 	\HIRElementDef{DimensionInterval[dimension]}
 	{Provides a specific range on a dimension to iterate over}{O}
@@ -216,7 +216,7 @@ The {\tt BoundaryCondition} defines the strategy to apply a boundary condition t
 	{field subject of boundary condition}{R}
 	\HIRElementDef{BlockStmt}
 	{BlockStmt with statement that implement the boundary condition computation}{R}
-		
+
 \end{HIRChildElements}
 
 \begin{HIRAttributes}

--- a/doc/statement_elements.tex
+++ b/doc/statement_elements.tex
@@ -50,7 +50,7 @@ The {\tt BlockStmt} is a statement element that defines an block (of statements)
 \subsubsection*{ContentsModel}{}
 
 \begin{lstlisting}[style=default]
-(^\concept{Stmt}^+)
+(^\concept{stmtModel}^+)
 \end{lstlisting}
 
 \begin{HIRChildElements}

--- a/doc/statement_elements.tex
+++ b/doc/statement_elements.tex
@@ -22,7 +22,7 @@ The {\tt VarDecl} represents a N-dimensional scalar.
 \end{HIRAttributes}
 
 \element{IfStmt}
-The {\tt IfStmt} is a statement element that defines an if condition. 
+The {\tt IfStmt} is a statement element that defines an if condition.
 
 \subsubsection*{ContentsModel}{}
 
@@ -45,7 +45,7 @@ else
 \end{HIRChildElements}
 
 \element{BlockStmt}
-The {\tt BlockStmt} is a statement element that defines an block (of statements). 
+The {\tt BlockStmt} is a statement element that defines an block (of statements).
 
 \subsubsection*{ContentsModel}{}
 
@@ -59,19 +59,10 @@ The {\tt BlockStmt} is a statement element that defines an block (of statements)
 \end{HIRChildElements}
 
 \element{Stmt}
-The {\tt Stmt} is an alias element to any element that is a statement. 
+The {\tt Stmt} is an alias element to any element that is a statement.
 
 \subsubsection*{ContentsModel}{}
 
 \begin{lstlisting}[style=default]
 (^\concept{VarDecl}^|^\concept{IfStmt}^|^\concept{BlockStmt}^|^\concept{IfStmt}^|^\concept{ExprStmt}^)
-\end{lstlisting}
-
-\element{ExprStmt}
-The {\tt ExprStmt} is a statement made by an expression
-
-\subsubsection*{ContentsModel}{}
-
-\begin{lstlisting}[style=default]
-(^\concept{UnaryOp}^|^\concept{TernaryOp}^|^\concept{AssignmentOp}^)
 \end{lstlisting}

--- a/doc/statement_elements.tex
+++ b/doc/statement_elements.tex
@@ -57,12 +57,3 @@ The {\tt BlockStmt} is a statement element that defines an block (of statements)
 	\HIRElementDef{Stmt}
 	{sequence of statements that compose the {\tt block} computation}{R}
 \end{HIRChildElements}
-
-\element{Stmt}
-The {\tt Stmt} is an alias element to any element that is a statement.
-
-\subsubsection*{ContentsModel}{}
-
-\begin{lstlisting}[style=default]
-(^\concept{VarDecl}^|^\concept{IfStmt}^|^\concept{BlockStmt}^|^\concept{IfStmt}^|^\concept{ExprStmt}^)
-\end{lstlisting}

--- a/doc/statement_elements.tex
+++ b/doc/statement_elements.tex
@@ -54,6 +54,6 @@ The {\tt BlockStmt} is a statement element that defines an block (of statements)
 \end{lstlisting}
 
 \begin{HIRChildElements}
-	\HIRElementDef{Stmt}
+	\HIRElementDef{stmtModel}
 	{sequence of statements that compose the {\tt block} computation}{R}
 \end{HIRChildElements}


### PR DESCRIPTION
* As discussed in the first review, `Stmt` and `ExprStmt` are more abstract concept than actual elements that we need in the representation. 